### PR TITLE
chore: bump vendor to libwebp-1.3.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn poke() {
         unsafe {
-            assert_eq!(66304, WebPGetEncoderVersion());
+            assert_eq!(66305, WebPGetEncoderVersion());
 
             let mut data = ::std::ptr::null_mut();
             let rgb = [1u8, 2, 3];


### PR DESCRIPTION
Update libwebp to 1.3.1 (might solve https://github.com/NoXF/libwebp-sys/issues/20)