### PR TITLE
test: add missing WebPFree/WebPPictureFree calls to prevent memory leaks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ mod tests {
 
             assert_eq!(b"RIFF", &out[0..4]);
             assert_eq!(b"WEBP", &out[8..12]);
+            WebPFree(out_buf as *mut _);
         }
     }
 
@@ -215,6 +216,7 @@ mod tests {
 
             assert_eq!(b"RIFF", &out[0..4]);
             assert_eq!(b"WEBP", &out[8..12]);
+            WebPFree(out_buf as *mut _);
         }
     }
 
@@ -259,6 +261,7 @@ mod tests {
 
             assert_eq!(b"RIFF", &out[0..4]);
             assert_eq!(b"WEBP", &out[8..12]);
+            WebPPictureFree(&mut picture);
         }
     }
 
@@ -285,6 +288,8 @@ mod tests {
 
             assert_eq!(b"RIFF", &out[0..4]);
             assert_eq!(b"WEBP", &out[8..12]);
+            WebPFree(decode_buf as *mut _);
+            WebPFree(out_buf as *mut _);
         }
     }
 


### PR DESCRIPTION
Hi team! Thanks for maintaining this essential crate.

While running some FFI memory analysis tooling across the test suite, I noticed a minor detail: a few C-allocated buffers in the unit tests are not being freed before the functions exit. 

To keep the test suite's memory footprint completely clean, this PR simply adds the missing `WebPFree` (for `decode_buf` and `out_buf`) and `WebPPictureFree` calls to the respective tests (`test_webp_decode`, `test_webp_encode`, `test_webp_encode_advanced`, etc.). 

It's a straightforward, trivial cleanup that just ensures strict resource management in the testing environment. Existing asserts pass as usual. Let me know if everything looks good!