### PR TITLE
DSP_INIT can be called from multiple threads

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -93,6 +93,7 @@ fn setup_build(build: &mut cc::Build, include_dir: &PathBuf) {
     build.include(include_dir);
     build.define("NDEBUG", Some("1"));
     build.define("_THREAD_SAFE", Some("1"));
+    build.define("WEBP_USE_THREAD", Some("1"));
     if !build.get_compiler().is_like_msvc() {
         build.flag("-fvisibility=hidden").flag("-Wall");
     } else {


### PR DESCRIPTION
I believe I ran into a case where multi-threaded programs get into `VP8LDspInit` concurrently and put the critical function pointers in a bad state which affects subsequent usage until program restart.

On this x86_64 system we have `SSE` and `AVX2` available and ended up in a state where both `VP8LPredictorsAdd[11]` and `VP8LPredictorsAdd_SSE[11]` point to the same `PredictorAdd11_AVX2` function leading to strange recursion and CPU saturation

A good case with a function pointers in a reasonable state looks like

```bash
sudo gdb -p ${pid} --batch \
-ex "set pagination off" \
-ex "print VP8LPredictorsAdd[11]" \
-ex "print VP8LPredictorsAdd_SSE[11]" \
-ex "print VP8LPredictorsAdd[11] == VP8LPredictorsAdd_SSE[11]" \
2>/dev/null

$1 = (VP8LPredictorsAddSubFunc) 0x55dc3dff7650 <PredictorAdd11_AVX2>
$2 = (VP8LPredictorsAddSubFunc) 0x55dc3dff8950 <PredictorAdd11_SSE2>
$3 = 0
```

Meanwhile a bad case looks like this

```bash
sudo gdb -p ${pid} --batch \
-ex "set pagination off" \
-ex "print VP8LPredictorsAdd[11]" \
-ex "print VP8LPredictorsAdd_SSE[11]" \
-ex "print VP8LPredictorsAdd[11] == VP8LPredictorsAdd_SSE[11]" \
2>/dev/null

$1 = (VP8LPredictorsAddSubFunc) 0x561e65724650 <PredictorAdd11_AVX2>
$2 = (VP8LPredictorsAddSubFunc) 0x561e65724650 <PredictorAdd11_AVX2>
$3 = 1
```

According to `perf` it seems to be stuck in `PredictorAdd11_AVX2`. So it seems to now call `VP8LPredictorsAdd_SSE[11]` for the remainder of the pixels which is just a pointer back to itself. I see that there exists the flag `WEBP_USE_THREAD` [here](https://github.com/webmproject/libwebp/blob/4fa21912338357f89e4fd51cf2368325b59e9bd9/CMakeLists.txt#L45) supposed to enable threading support by enabling the `pthread_mutex` path during initialization.